### PR TITLE
chore: Add caching functionality to GRPClient class

### DIFF
--- a/omni_pro_grpc/grpc_connector.py
+++ b/omni_pro_grpc/grpc_connector.py
@@ -1,12 +1,15 @@
+import hashlib
 import importlib
 
 import grpc
+from google.protobuf.message import Message as MessageResponse
 from grpc._channel import Channel
 from grpc.experimental import _insecure_channel_credentials
+from omni.pro.database.redis import RedisCache
 from omni_pro_base.config import Config
 from omni_pro_base.logger import configure_logger
 from omni_pro_base.util import nested
-from omni_pro_grpc.util import format_request
+from omni_pro_grpc.util import MessageToDict, format_request
 from omni_pro_redis.redis import RedisManager
 
 logger = configure_logger(name=__name__)
@@ -29,6 +32,22 @@ class Event(dict):
         self["module_pb2"] = module_pb2
         self["request_class"] = request_class
         self["params"] = params
+
+    def get_hash_256(self) -> str:
+        """
+        Generates a SHA-256 hash for the given payload.
+
+        Returns:
+            str: The SHA-256 hash of the payload.
+        """
+
+        payload = {
+            "rpc_method": self.get("rpc_method"),
+            "module_pb2": self.get("module_pb2"),
+            "request_class": self.get("request_class"),
+            "params": self.get("params"),
+        }
+        return hashlib.sha256(str(payload).encode()).hexdigest()
 
 
 class OmniChannel(Channel):
@@ -65,7 +84,7 @@ class GRPClient(object):
     def __init__(self, service_id: str):
         self.service_id = service_id
 
-    def call_rpc_fuction(self, event: Event, *args, **kwargs):
+    def call_rpc_fuction(self, event: Event, cache=False, *args, **kwargs):
         """
         function to call rpc function
         :param event: Event with params to call rpc function
@@ -81,6 +100,7 @@ class GRPClient(object):
         response, success = GRPClient(service_id=Config.SERVICE_ID).call_rpc_fuction(event)
         ```
         """
+        self.tennat = nested(event, "params.context.tenant")
         with OmniChannel(
             self.service_id,
             options=[
@@ -89,7 +109,7 @@ class GRPClient(object):
             ],
             *args,
             **kwargs,
-            tennat=nested(event, "params.context.tenant"),
+            tennat=self.tennat,
         ) as channel:
             stub = event.get("service_stub")
             stub_classname = event.get("stub_classname")
@@ -98,10 +118,79 @@ class GRPClient(object):
             stub = getattr(module_grpc, stub_classname)(channel)
             request_class = event.get("request_class")
             module_pb2 = importlib.import_module(f"{path_module}.{event.get('module_pb2')}")
+            if cache and self.validate_method_read(event.get("rpc_method")):
+                resul_cache = self.get_cache(event, module_pb2)
+                if resul_cache:
+                    return resul_cache, True
+
             request = format_request(event.get("params"), request_class, module_pb2)
             # Instance the method rpc que recibe el request
             response = getattr(stub, event.get("rpc_method"))(request)
+            if cache and self.validate_method_read(event.get("rpc_method")):
+                self.save_cache(event, response)
             success = True
             if hasattr(response, "response_standard"):
                 success = response.response_standard.status_code in range(200, 300)
             return response, success
+
+    def get_cache(self, event: Event, module_pb2) -> MessageResponse:
+        """
+        Validates the cache for a given event.
+
+        Args:
+            event (Event): The event to validate the cache for.
+            module_pb2 (ModuleType): The module_pb2 module.
+
+        Returns:
+            Message formatted request if the cache is valid, None otherwise.
+        """
+        self.redis_cache = self.set_cache_redis()
+        hash_key = event.get_hash_256()
+        data = self.redis_cache.get_cache(hash_key)
+        if data:
+            response_class_name = data.pop("response_class_name")
+            return format_request(data, response_class_name, module_pb2)
+
+    def set_cache_redis(self) -> RedisCache:
+        """
+        Sets up and returns a RedisCache object based on the configuration retrieved from RedisManager.
+
+        Returns:
+            RedisCache: The RedisCache object configured with the appropriate host, port, db, and redis_ssl settings.
+        """
+        redis = RedisManager(
+            host=Config.REDIS_HOST, port=Config.REDIS_PORT, db=Config.REDIS_DB, redis_ssl=Config.REDIS_SSL
+        )
+        config = redis.get_resource_config(Config.SAAS_REDIS_CACHE, self.tennat)
+        return RedisCache(
+            host=config.get("host"), port=config.get("port"), db=config.get("db"), redis_ssl=config.get("redis_ssl")
+        )
+
+    def save_cache(self, event: Event, message: MessageResponse):
+        """
+        Saves the cache for the given event and message response.
+
+        Args:
+            event (Event): The event object.
+            message (MessageResponse): The message response object.
+
+        Returns:
+            None
+        """
+        hash_key = event.get_hash_256()
+        response_class_name = message.__class__.__name__
+        data = MessageToDict(message)
+        data["response_class_name"] = response_class_name
+        self.redis_cache.save_cache(hash_key, data)
+
+    def validate_method_read(self, method: str) -> bool:
+        """
+        Validates if the given method is a read method.
+
+        Args:
+            method (str): The method to be validated.
+
+        Returns:
+            bool: True if the method is a read method, False otherwise.
+        """
+        return "Read" in method


### PR DESCRIPTION
# NVOMS-2743

## ref 
https://omnipro.atlassian.net/browse/NVOMS-2743

## Descripción
Este PR introduce varias mejoras y refactorizaciones en el archivo `grpc_connector.py`. Se han añadido nuevas funcionalidades para la gestión de caché, la validación de métodos y la obtención de hash.

## Cambios
- **Nuevas importaciones**:
  - Se añadió la importación de `RedisCache` para la gestión de caché.
  - Se añadió la importación de `MessageToDict` para la conversión de mensajes.
  - Otras utilidades necesarias para el refactor.

- **Funciones añadidas**:
  - `get_hash_256()`: Genera un hash SHA-256 para el payload dado.
  - `call_rpc_function()`: Se modificó para aceptar el parámetro `cache` que indica si se debe usar caché.
  - `get_cache()`: Valida el caché para un evento dado.
  - `set_cache_redis()`: Configura la caché Redis basada en la configuración obtenida de `RedisManager`.
  - `save_cache()`: Guarda la respuesta de un mensaje en la caché.
  - `validate_method_read()`: Valida si el método dado es de lectura.

## Motivación y contexto
Estas mejoras y refactorizaciones son necesarias para optimizar el manejo de caché y mejorar la seguridad y eficiencia de las operaciones gRPC. Además, la validación de métodos asegura que solo los métodos `read`  puedan ser ejecutados

## Cómo se ha probado
- Se realizaron pruebas unitarias para verificar la correcta funcionalidad de las nuevas funciones.
- Se probaron escenarios donde la caché debe ser utilizada y validada.
- Se verificó que los métodos no permitidos sean correctamente rechazados.

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [x] Nueva característica (cambios que añaden funcionalidad)
- [] Refactorización (cambio de código sin impacto en la funcionalidad)
- [ ] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [ ] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [x] Mi código sigue las directrices de estilo de este proyecto
- [x] He realizado una auto-revisión de mi propio código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He hecho cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevas advertencias
- [x] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [x] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [x] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales

- Se requiere agregar el recurso al tenant en redis
```
"saas-redis-cache": {
    "host": "localhost",
    "port": 6379,
    "db": 3,
    "ssl": false
}
```

la llave(nombre del recurso) es necesario pasarla como una variable de entorno, al igual que el tiempo de expiración de la cache, el nombre de las variables son

- SAAS_REDIS_CACHE
- EXPIRE_CACHE
