### PR TITLE
Add HealthServer class for gRPC health checking with toggle functionality

### DIFF
--- a/omni_pro_grpc/grpc_connector.py
+++ b/omni_pro_grpc/grpc_connector.py
@@ -107,7 +107,8 @@ class GRPClient(object):
         response, success = GRPClient(service_id=Config.SERVICE_ID).call_rpc_fuction(event)
         ```
         """
-        self.tenant = nested(event, "params.context.tenant")
+        path_module = kwargs.pop("path_module", "omni_pro_grpc")
+        self.tenant = kwargs.pop("tenant", nested(event, "params.context.tenant"))
         with OmniChannel(
             self.service_id,
             options=[
@@ -120,7 +121,6 @@ class GRPClient(object):
         ) as channel:
             stub = event.get("service_stub")
             self.stub_classname = event.get("stub_classname")
-            path_module = "omni_pro_grpc"
             self.module_grpc = importlib.import_module(f"{path_module}.{event.get('module_grpc')}")
             stub = getattr(self.module_grpc, self.stub_classname)(channel)
             request_class = event.get("request_class")

--- a/omni_pro_grpc/grpc_health_check.py
+++ b/omni_pro_grpc/grpc_health_check.py
@@ -1,0 +1,37 @@
+import threading
+from concurrent import futures
+from time import sleep
+
+import grpc
+from grpc_health.v1 import health, health_pb2, health_pb2_grpc
+
+
+class HealthServer(object):
+
+    def __init__(self, server: grpc.Server, service: str = "health", max_workers: int = 10, sleep_time: int = 5):
+        self.server = server
+        self.service = service
+        self.max_workers = max_workers
+        self.sleep_time = sleep_time
+
+    def _toggle_health(self, health_servicer: health.HealthServicer):
+        next_status = health_pb2.HealthCheckResponse.SERVING
+        while True:
+            if next_status == health_pb2.HealthCheckResponse.SERVING:
+                next_status = health_pb2.HealthCheckResponse.NOT_SERVING
+            else:
+                next_status = health_pb2.HealthCheckResponse.SERVING
+
+            health_servicer.set(self.service, next_status)
+            sleep(self.sleep_time)
+
+    def configure_health_server(self):
+        health_servicer = health.HealthServicer(
+            experimental_non_blocking=True,
+            experimental_thread_pool=futures.ThreadPoolExecutor(max_workers=self.max_workers),
+        )
+        health_pb2_grpc.add_HealthServicer_to_server(health_servicer, self.server)
+
+        # Use a daemon thread to toggle health status
+        toggle_health_status_thread = threading.Thread(target=self._toggle_health, args=(health_servicer,), daemon=True)
+        toggle_health_status_thread.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 grpcio==1.56.0
 grpcio-tools==1.56.0
 protobuf==4.23.4
+grpcio-health-checking==1.56.0


### PR DESCRIPTION
# [NVOMS-3056](https://omnipro.atlassian.net/browse/NVOMS-3056) - Adaptar los registros de modelo a CELERY al usar task

## ref [NVOMS-3056](https://omnipro.atlassian.net/browse/NVOMS-3056)

## Descripción

He añadido una nueva funcionalidad de verificación de estado de salud a nuestro servidor gRPC. Con esta implementación, he creado un archivo nuevo llamado `grpc_health_check.py` que proporciona una clase `HealthServer` diseñada para alternar continuamente el estado de salud del servicio entre "SERVING" y "NOT_SERVING", en intervalos de tiempo especificados. Este cambio permite simular condiciones de servicio de forma dinámica y probar la capacidad de respuesta y comportamiento del sistema bajo distintos estados de servicio.

## Cambios

He introducido un nuevo archivo de script que define la clase `HealthServer`. Este script configura un servidor de salud gRPC utilizando `grpc_health.v1.health` para gestionar el estado del servicio. El servidor de salud alterna entre estados "SERVING" y "NOT_SERVING" utilizando un subproceso daemon que cambia estos estados en un ciclo determinado por el tiempo de espera (sleep time). La clase acepta parámetros configurables como `max_workers` y `sleep_time` para manejar el número de hilos y el tiempo de ciclo entre cambios de estado, respectivamente. Esta configuración utiliza una implementación no bloqueante y un pool de hilos para manejar de manera eficiente las solicitudes de salud.

## Motivación y contexto

La motivación detrás de estos cambios es mejorar la capacidad de monitoreo y prueba de nuestro servidor gRPC. Al tener un sistema que alterna automáticamente su estado de salud, podemos simular diferentes escenarios de disponibilidad y responder proactivamente a problemas potenciales. Además, este mecanismo ofrece una herramienta valiosa para realizar pruebas de carga y de resiliencia del sistema, asegurando que el servicio pueda manejar cambios abruptos en su estado sin afectar la funcionalidad general. Esto proporciona un marco más robusto para garantizar la calidad y rendimiento del sistema a largo plazo.

## Cómo se prueba

Para probar estos cambios:

El nuevo servidor de salud se puede probar integrándolo con el servidor gRPC principal. Una vez configurado, ejecutar el servidor y observar el registro de salida, confirmando que el estado de salud cambia entre "SERVING" y "NOT_SERVING" según el intervalo de tiempo especificado.

## Screenshots (si aplica)
\#N/A

## Tipo de cambio
- [ ] Bug fix (cambios que solucionan un problema)
- [X] Nueva característica (cambios que añaden funcionalidad)
- [X] Cambios de breaks (cambio que requiere una modificación en el código existente o en la configuración)
- [X] Mejoras de rendimiento
- [ ] Otro (especificar)

## Checklist:
- [X] Mi código sigue las directrices de estilo de este proyecto
- [X] He realizado una auto-revisión de mi propio código
- [X] He comentado mi código, especialmente en áreas difíciles de entender
- [X] He hecho cambios correspondientes en la documentación
- [X] Mis cambios no generan nuevas advertencias
- [X] He añadido pruebas que demuestran que mi arreglo es efectivo o que mi característica funciona
- [X] Los cambios necesarios han sido confirmados como efectivos y deseados en pruebas
- [X] Debería ser revisado por al menos un desarrollador más antes de fusionarse

## Notas adicionales
\#N/A

[NVOMS-3056]: https://omnipro.atlassian.net/browse/NVOMS-3056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NVOMS-3056]: https://omnipro.atlassian.net/browse/NVOMS-3056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ